### PR TITLE
Do not apply orientation constraints

### DIFF
--- a/src/slider.tsx
+++ b/src/slider.tsx
@@ -120,13 +120,6 @@ export const Compare2D = <T extends 'horizontal' | 'vertical' | '2d' = '2d'>({
         Math.min(100, ((clientY - rect.top) / rect.height) * 100)
       )
 
-      // Apply orientation constraints
-      if (orientation === 'horizontal') {
-        y = 50 // Fixed at center for horizontal mode
-      } else if (orientation === 'vertical') {
-        x = 50 // Fixed at center for vertical mode
-      }
-
       const newPosition = { x, y }
       if (!isControlled) {
         setInternalPosition(newPosition)
@@ -242,13 +235,6 @@ export const Compare2D = <T extends 'horizontal' | 'vertical' | '2d' = '2d'>({
           break
         default:
           return
-      }
-
-      // Apply orientation constraints
-      if (orientation === 'horizontal') {
-        newY = 50
-      } else if (orientation === 'vertical') {
-        newX = 50
       }
 
       const newPosition = { x: newX, y: newY }


### PR DESCRIPTION
Slider handle should snap to the mouse cursor for all orientations, so `apply constraints` should not be applied. Otherwise best to use standard purely horizontal/vertical [mattrothenberg/react-comparison-slider](https://github.com/mattrothenberg/react-comparison-slider).

A few remarks: 
 - Should this `snapHandleToMouse` behavior be controllable via a prop? [nerdyman/react-compare-slider ](https://github.com/nerdyman/react-compare-slider) calls it `onlyHandleDraggable`
 - Also, can this [switch-case](https://github.com/mattrothenberg/react-compare-2d/blob/e222e5ef4fca91ca81a6d51edfc07949a4a53339/src/slider.tsx#L34-L41) be removed to only `return { x: 50, y: 50 }`? 
 - Could we add another prop so the slider can be moved only if the handle or the gutter lines get clicked? Could be by applying `onMouseDown={handleMouseDown}` only to the handle and lines? 
 - In that case, dragging the slider handles should have a different effect, only dragging vertically/horizontally. 
